### PR TITLE
sk/threading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ lib*.pc
 /Release/
 /tmp_install/
 /portlock/
+compile_commands.json

--- a/src/backend/access/transam/xlogrecovery.c
+++ b/src/backend/access/transam/xlogrecovery.c
@@ -91,7 +91,7 @@ postmaster_guc char	   *recovery_target_time_string;
 session_local TimestampTz recoveryTargetTime;
 session_local const char *recoveryTargetName;
 session_local XLogRecPtr	recoveryTargetLSN;
-session_local int			recovery_min_apply_delay = 0;
+sighup_guc int			recovery_min_apply_delay = 0;
 
 /* options formerly taken from recovery.conf for XLOG streaming */
 sighup_guc char	   *PrimaryConnInfo = NULL;

--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -296,8 +296,8 @@ spcachekey_equal(SearchPathCacheKey a, SearchPathCacheKey b)
  */
 #define SPCACHE_RESET_THRESHOLD		256
 
-static nsphash_hash *SearchPathCache = NULL;
-static SearchPathCacheEntry *LastSearchPathCacheEntry = NULL;
+static session_local nsphash_hash *SearchPathCache = NULL;
+static session_local SearchPathCacheEntry *LastSearchPathCacheEntry = NULL;
 
 /*
  * Create or reset search_path cache as necessary.

--- a/src/backend/port/sysv_sema.c
+++ b/src/backend/port/sysv_sema.c
@@ -58,9 +58,9 @@ typedef int IpcSemaphoreId;		/* semaphore ID returned by semget(2) */
 #define PGSemaMagic		537		/* must be less than SEMVMX */
 
 
-static global PGSemaphore sharedSemas; /* array of PGSemaphoreData in shared memory */
-static global int	numSharedSemas;		/* number of PGSemaphoreDatas used so far */
-static global int	maxSharedSemas;		/* allocated size of PGSemaphoreData array */
+static pg_global PGSemaphore sharedSemas; /* array of PGSemaphoreData in shared memory */
+static pg_global int	numSharedSemas;		/* number of PGSemaphoreDatas used so far */
+static pg_global int	maxSharedSemas;		/* allocated size of PGSemaphoreData array */
 static session_local IpcSemaphoreId *mySemaSets;	/* IDs of sema sets acquired so far */
 static session_local int	numSemaSets;		/* number of sema sets acquired so far */
 static session_local int	maxSemaSets;		/* allocated size of mySemaSets array */

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1324,7 +1324,7 @@ PostmasterMain(int argc, char *argv[])
 	 * behavior in a multithreaded program.  A multithreaded postmaster is the
 	 * normal case on Windows, which offers neither fork() nor sigprocmask().
 	 */
-	if (pthread_is_threaded_np() != 0)
+	if (pthread_is_threaded_np() != 0 && !IsMultiThreaded)
 		ereport(FATAL,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("postmaster became multithreaded during startup"),
@@ -1692,7 +1692,7 @@ ServerLoop(void)
 		 * With assertions enabled, check regularly for appearance of
 		 * additional threads.  All builds check at start and exit.
 		 */
-		Assert(pthread_is_threaded_np() == 0);
+		Assert(pthread_is_threaded_np() == 0 || IsMultiThreaded);
 #endif
 
 		/*
@@ -3471,7 +3471,7 @@ ExitPostmaster(int status)
 	 * This message uses LOG level, because an unclean shutdown at this point
 	 * would usually not look much different from a clean shutdown.
 	 */
-	if (pthread_is_threaded_np() != 0)
+	if (pthread_is_threaded_np() != 0 && !IsMultiThreaded)
 		ereport(LOG,
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 errmsg_internal("postmaster became multithreaded"),

--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -252,7 +252,7 @@ typedef struct TransInvalidationInfo
 
 static session_local TransInvalidationInfo *transInvalInfo = NULL;
 
-static InvalidationInfo *inplaceInvalInfo = NULL;
+static session_local InvalidationInfo *inplaceInvalInfo = NULL;
 
 /* GUC storage */
 session_guc int			debug_discard_caches = 0;

--- a/src/backend/utils/cache/typcache.c
+++ b/src/backend/utils/cache/typcache.c
@@ -84,7 +84,7 @@ static session_local HTAB *TypeCacheHash = NULL;
  * to clear i.e it has either TCFLAGS_HAVE_PG_TYPE_DATA, or
  * TCFLAGS_OPERATOR_FLAGS, or tupdesc.
  */
-static HTAB *RelIdToTypeIdCacheHash = NULL;
+static session_local HTAB *RelIdToTypeIdCacheHash = NULL;
 
 typedef struct RelIdToTypeIdCacheEntry
 {
@@ -223,9 +223,9 @@ typedef struct SharedTypmodTableEntry
 	dsa_pointer shared_tupdesc;
 } SharedTypmodTableEntry;
 
-static Oid *in_progress_list;
-static int	in_progress_list_len;
-static int	in_progress_list_maxlen;
+static session_local Oid *in_progress_list;
+static session_local int	in_progress_list_len;
+static session_local int	in_progress_list_maxlen;
 
 /*
  * A comparator function for SharedRecordTableKey.

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -121,7 +121,7 @@ pg_global bool		IsBinaryUpgrade = false;
 
 session_guc bool		ExitOnAnyError = false;
 
-postmaster_guc bool		IsMultiThreaded = false; /* GUC */
+postmaster_guc bool		IsMultiThreaded = true; /* GUC */
 
 session_local int			DateStyle = USE_ISO_DATES;
 session_local int			DateOrder = DATEORDER_MDY;

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -1192,7 +1192,7 @@ static_singleton struct config_bool ConfigureNamesBool[] =
 			GUC_SUPERUSER_ONLY | GUC_NO_RESET_ALL | GUC_NO_RESET
 		},
 		GUC_ADDR(IsMultiThreaded),
-		false,
+		true,
 		NULL, NULL, NULL
 	},
 	{

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -34,7 +34,7 @@ extern PGDLLIMPORT session_local XLogRecPtr XactLastRecEnd;
 extern PGDLLIMPORT session_local XLogRecPtr XactLastCommitEnd;
 
 /* these variables are GUC parameters related to XLOG */
-extern PGDLLIMPORT pg_global int wal_segment_size;
+extern PGDLLIMPORT internal_guc int wal_segment_size;
 extern PGDLLIMPORT sighup_guc int min_wal_size_mb;
 extern PGDLLIMPORT sighup_guc int max_wal_size_mb;
 extern PGDLLIMPORT sighup_guc int wal_keep_size_mb;
@@ -51,7 +51,7 @@ extern PGDLLIMPORT session_guc bool wal_init_zero;
 extern PGDLLIMPORT session_guc bool wal_recycle;
 extern PGDLLIMPORT session_guc bool *wal_consistency_checking;
 extern PGDLLIMPORT session_guc char *wal_consistency_checking_string;
-extern PGDLLIMPORT session_guc bool log_checkpoints;
+extern PGDLLIMPORT sighup_guc bool log_checkpoints;
 extern PGDLLIMPORT session_guc int CommitDelay;
 extern PGDLLIMPORT session_guc int CommitSiblings;
 extern PGDLLIMPORT session_guc bool track_wal_io_timing;

--- a/src/include/access/xlogrecovery.h
+++ b/src/include/access/xlogrecovery.h
@@ -65,7 +65,7 @@ extern PGDLLIMPORT session_local TimestampTz recoveryTargetTime;
 extern PGDLLIMPORT session_local const char *recoveryTargetName;
 extern PGDLLIMPORT session_local XLogRecPtr recoveryTargetLSN;
 extern PGDLLIMPORT session_local RecoveryTargetType recoveryTarget;
-extern PGDLLIMPORT session_local bool wal_receiver_create_temp_slot;
+extern PGDLLIMPORT sighup_guc bool wal_receiver_create_temp_slot;
 extern PGDLLIMPORT session_local RecoveryTargetTimeLineGoal recoveryTargetTimeLineGoal;
 extern PGDLLIMPORT session_local TimeLineID recoveryTargetTLIRequested;
 extern PGDLLIMPORT session_local TimeLineID recoveryTargetTLI;

--- a/src/include/postmaster/postmaster.h
+++ b/src/include/postmaster/postmaster.h
@@ -44,7 +44,7 @@ typedef union
 	pthread_t	threadid;
 } pid_or_threadid;
 
-extern pg_global bool IsMultiThreaded;
+extern postmaster_guc bool IsMultiThreaded;
 static inline bool
 pid_eq(pid_or_threadid a, pid_or_threadid b)
 {

--- a/src/include/replication/slotsync.h
+++ b/src/include/replication/slotsync.h
@@ -20,8 +20,8 @@ extern PGDLLIMPORT bool sync_replication_slots;
  * GUCs needed by slot sync worker to connect to the primary
  * server and carry on with slots synchronization.
  */
-extern PGDLLIMPORT session_guc char *PrimaryConnInfo;
-extern PGDLLIMPORT session_guc char *PrimarySlotName;
+extern PGDLLIMPORT sighup_guc char *PrimaryConnInfo;
+extern PGDLLIMPORT sighup_guc char *PrimarySlotName;
 
 extern char *CheckAndGetDbnameFromConninfo(void);
 extern bool ValidateSlotSyncParams(int elevel);

--- a/src/include/storage/bufmgr.h
+++ b/src/include/storage/bufmgr.h
@@ -165,7 +165,7 @@ extern PGDLLIMPORT session_guc int maintenance_io_concurrency;
 #define DEFAULT_IO_COMBINE_LIMIT Min(MAX_IO_COMBINE_LIMIT, (128 * 1024) / BLCKSZ)
 extern PGDLLIMPORT session_guc int io_combine_limit;
 
-extern PGDLLIMPORT session_guc int checkpoint_flush_after;
+extern PGDLLIMPORT sighup_guc int checkpoint_flush_after;
 extern PGDLLIMPORT session_guc int backend_flush_after;
 extern PGDLLIMPORT sighup_guc int bgwriter_flush_after;
 

--- a/src/include/utils/bytea.h
+++ b/src/include/utils/bytea.h
@@ -22,7 +22,7 @@ typedef enum
 	BYTEA_OUTPUT_HEX,
 }			ByteaOutputType;
 
-extern PGDLLIMPORT session_local int bytea_output;	/* ByteaOutputType, but int for GUC
+extern PGDLLIMPORT session_guc int bytea_output;	/* ByteaOutputType, but int for GUC
 										 * enum */
 
 #endif							/* BYTEA_H */

--- a/src/tools/pgguclifetimes/.gitignore
+++ b/src/tools/pgguclifetimes/.gitignore
@@ -1,0 +1,2 @@
+pg_static_vars
+pgguclifetimes

--- a/src/tools/pgguclifetimes/Makefile
+++ b/src/tools/pgguclifetimes/Makefile
@@ -32,7 +32,7 @@ pgguclifetimes: $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -lclang -o $@$(X)
 
 pg_static_vars: pg_static_vars.cpp
-	$(CC) -std=c++20 $(CFLAGS) $(OBJS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS)  -lc++ -x c++ -lclang -o $@$(X)
+	$(CXX) -std=c++20 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -Wno-unneeded-internal-declaration -o $@$(X) $<
 
 clean distclean:
 	rm -f pgguclifetimes$(X) pg_static_vars$(X) $(OBJS)

--- a/src/tools/pgguclifetimes/Makefile
+++ b/src/tools/pgguclifetimes/Makefile
@@ -31,7 +31,7 @@ all: pgguclifetimes pg_static_vars
 pgguclifetimes: $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -lclang -o $@$(X)
 
-pg_static_vars: pg_static_vars.cpp
+pg_static_vars: pg_static_vars.o
 	$(CXX) -std=c++20 $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -Wno-unneeded-internal-declaration -o $@$(X) $<
 
 clean distclean:

--- a/src/tools/pgguclifetimes/Makefile
+++ b/src/tools/pgguclifetimes/Makefile
@@ -26,10 +26,13 @@ OBJS = \
 	pgguclifetimes.o \
 	vector.o
 
-all: pgguclifetimes
+all: pgguclifetimes pg_static_vars
 
 pgguclifetimes: $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -lclang -o $@$(X)
 
+pg_static_vars: pg_static_vars.cpp
+	$(CC) -std=c++20 $(CFLAGS) $(OBJS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS)  -lc++ -x c++ -lclang -o $@$(X)
+
 clean distclean:
-	rm -f pgguclifetimes$(X) $(OBJS)
+	rm -f pgguclifetimes$(X) pg_static_vars$(X) $(OBJS)

--- a/src/tools/pgguclifetimes/pg_static_vars.cpp
+++ b/src/tools/pgguclifetimes/pg_static_vars.cpp
@@ -1,0 +1,373 @@
+//
+// This program builds without issues when postgres was vonfigured with  --with-llvm flag.
+//
+// To run it needs a compilation database also known as compile_commands.json file. One
+// way to do it is to wrap make with bear tool (https://github.com/rizsotto/Bear). For
+// example:
+//   bear -- make -j
+//
+// Another way is to use meson build system (TODO: test it).
+//
+
+#include <clang-c/Index.h>
+#include <clang-c/CXCompilationDatabase.h>
+
+#include <cstdio>
+#include <vector>
+#include <format>
+#include <cassert>
+#include <filesystem>
+#include <set>
+#include <iostream>
+#include <sstream>
+
+constexpr bool PRINT_TREE_WALK = false;
+
+bool withUnannotated = false;
+bool skipYacc = true;
+
+struct VisitorData
+{
+    int depth = 1;
+    bool var_decl_subtree = false;
+    std::vector<const char*> annotations;
+};
+
+std::set<std::string> known_vars;
+
+// Print relevant information about each node maintaining indentation.
+// Disabled by default, set PRINT_TREE_WALK to enable.
+void debug_tree_node(CXCursor current_cursor, VisitorData* data)
+{
+    const CXCursorKind cursor_kind = clang_getCursorKind(current_cursor);
+    const bool is_attr = clang_isAttribute(cursor_kind) != 0;
+    const bool has_attr = clang_Cursor_hasAttrs(current_cursor);
+
+    const CXString display_name = clang_getCursorDisplayName(current_cursor);
+    const CXString kind_spelling = clang_getCursorKindSpelling(cursor_kind);
+    const CXType cursor_type = clang_getCursorType(current_cursor);
+    const CXString type_spelling = clang_getTypeSpelling(cursor_type);
+
+    CXString loc;
+    unsigned line, column;
+    clang_getPresumedLocation(clang_getCursorLocation(current_cursor), &loc, &line, &column);
+
+    std::string indent(data->depth * 2, '-');
+    printf("%s: %s '%s' <%s> %s%s (%s:%u:%u, isFromMainFile=%d)\n",
+        indent.c_str(),
+        clang_getCString(kind_spelling),
+        clang_getCString(display_name),
+        clang_getCString(type_spelling),
+        is_attr ? "[IS_ATTR] " : "",
+        has_attr ? "[HAS_ATTR] " : "",
+        clang_getCString(loc), line, column,
+        clang_Location_isFromMainFile(clang_getCursorLocation(current_cursor)));
+
+    clang_disposeString(type_spelling);
+    clang_disposeString(kind_spelling);
+    clang_disposeString(display_name);
+}
+
+void process_var(CXCursor current_cursor, std::vector<const char *> annotations)
+{
+    const CXType type = clang_getCursorType(current_cursor);
+
+    const CXString var_name_cxs = clang_getCursorDisplayName(current_cursor);
+    const std::string var_name = clang_getCString(var_name_cxs);
+    clang_disposeString(var_name_cxs);
+
+    const CXString type_name_cxs = clang_getTypeSpelling(type);
+    std::string type_name = clang_getCString(type_name_cxs);
+    clang_disposeString(type_name_cxs);
+
+    CXString file;
+    unsigned line, column;
+    clang_getPresumedLocation(clang_getCursorLocation(current_cursor), &file, &line, &column);
+    std::ostringstream oss;
+    oss << std::filesystem::path(clang_getCString(file)).lexically_normal().string()
+        << ":" << line
+        << ":" << column;
+    const std::string location = oss.str();
+
+    // Skip already seen vars. We iterate over all c files, hence declarations
+    // from headers might appear multiple times.
+    const std::string name_loc = var_name + ":" + location;
+    auto result = known_vars.insert(name_loc);
+    if (!result.second) {
+        return;
+    }
+
+    // skip `no_such_variable` variables which are used in BKI macroses
+    if (std::string_view(var_name.data()) == "no_such_variable") {
+        return;
+    }
+
+    // skip yacc files by checking "yy" in the name
+    // TODO: some better heuristic
+    if (skipYacc && std::string_view(var_name.data()).find("yy") != std::string::npos) {
+        return;
+    }
+
+    // skip const variables
+    if (clang_isConstQualifiedType(type)) {
+        return;
+    } else if (std::string_view(type_name.data(), 6) == "const ") {
+        // somehow clang_isConstQualifiedType does not work for const arrays, check const prefix
+        return;
+    }
+
+    // ok, print it
+
+    // annotations list
+    std::string annotation;
+    if (!annotations.empty()) {
+        annotation = annotations[0];
+        for (size_t i = 1; i < annotations.size(); ++i) {
+            annotation += std::string(", ") + annotations[i];
+        }
+    } else {
+        annotation = "";
+    }
+
+    if (annotations.size() > 1) {
+        fprintf(stderr, "WARNING: Multiple annotations: %s\n", annotation.c_str());
+    }
+
+    if (withUnannotated || annotation.empty()) {
+        fprintf(stdout, "[%s]\t%s\t%s\t%s\n",
+                annotation.c_str(),
+                var_name.c_str(),
+                type_name.c_str(),
+                location.c_str());
+    }
+}
+
+static CXChildVisitResult VisitTU(CXCursor current_cursor, CXCursor parent, CXClientData client_data)
+{
+    VisitorData* data = reinterpret_cast<VisitorData*>(client_data);
+    bool top_var_decl = false;
+
+    VisitorData child_data;
+    child_data.depth = data->depth + 1;
+    child_data.var_decl_subtree = data->var_decl_subtree;
+
+    const CXCursorKind cursor_kind = clang_getCursorKind(current_cursor);
+
+    // Attributes are in child nodes, grab names in recursive calls
+    //
+    // NB: clang_Location_isFromMainFile(clang_getCursorLocation()) is not properly inherited by attribute children,
+    // see https://github.com/llvm/llvm-project/issues/87813 for details.
+    if (cursor_kind == CXCursor_VarDecl && clang_Location_isInSystemHeader(clang_getCursorLocation(current_cursor)) == 0) {
+        child_data.var_decl_subtree = true;
+        top_var_decl = true;
+    }
+
+    if (cursor_kind == CXCursor_AnnotateAttr && data->var_decl_subtree) {
+        data->annotations.push_back(clang_getCString(clang_getCursorSpelling(current_cursor)));
+    }
+
+    if constexpr(PRINT_TREE_WALK) {
+        debug_tree_node(current_cursor, data);
+    }
+
+    // recurse into subtree
+    clang_visitChildren(current_cursor, VisitTU, &child_data);
+
+    if (top_var_decl) {
+        process_var(current_cursor, child_data.annotations );
+    }
+
+    return CXChildVisit_Continue;
+};
+
+// Function to process each translation unit (TU)
+void processTranslationUnit(const char *filename, CXCompilationDatabase compilationDB) {
+    // Arguments needed for parsing each TU, usually retrieved from the compilation database
+    CXCompileCommands commands = clang_CompilationDatabase_getCompileCommands(compilationDB, filename);
+
+    if (commands == NULL) {
+        fprintf(stderr, "No compile commands found for %s\n", filename);
+        return;
+    }
+
+    unsigned commandCount = clang_CompileCommands_getSize(commands);
+    for (unsigned i = 0; i < commandCount; ++i) {
+        CXCompileCommand command = clang_CompileCommands_getCommand(commands, i);
+        CXString directory = clang_CompileCommand_getDirectory(command);
+        std::string source_dir = clang_getCString(directory);
+        unsigned numArgs = clang_CompileCommand_getNumArgs(command);
+
+        std::vector<std::string> args;
+        // Skip the last argument, which is the filename
+        for (unsigned j = 0; j < numArgs - 1; ++j) { 
+            CXString arg = clang_CompileCommand_getArg(command, j);
+            std::string arg_str = clang_getCString(arg);
+
+            // Change relative include paths to absolute paths
+            if (arg_str.rfind("-I", 0) == 0 && arg_str.size() > 2) {
+                std::string include_path = arg_str.substr(2);
+                if (!std::filesystem::path(include_path).is_absolute()) {
+                    include_path = std::filesystem::absolute(std::filesystem::path(source_dir) / include_path).string();
+                    arg_str = "-I" + include_path;
+                }
+            }
+
+            args.push_back(arg_str);
+            clang_disposeString(arg);
+        }
+
+        // Add the additional include path
+        //
+        // FIXME: ideally this should be present in the compilation database. But on macOS, it
+        // is not and that e.g. breaks stdbool inclusion. Which in turn make clang parse VarDecl
+        // as FunctionDecl.
+        args.push_back("-I/Library/Developer/CommandLineTools/usr/lib/clang/16/include/");
+
+        // Convert the vector of strings to a const char** array for compatibility with Clang API
+        std::vector<const char*> c_args;
+        for (const std::string& arg : args) {
+            c_args.push_back(arg.c_str());
+        }
+
+        // Parse the translation unit
+        CXIndex index = clang_createIndex(0, 0);
+        CXTranslationUnit translationUnit;
+        auto err = clang_parseTranslationUnit2FullArgv(
+            index, filename, c_args.data(), numArgs, NULL, 0,
+            CXTranslationUnit_SkipFunctionBodies
+                | CXTranslationUnit_VisitImplicitAttributes
+		        | CXTranslationUnit_KeepGoing,
+            &translationUnit);
+
+        if (err != CXError_Success) {
+            fprintf(stderr, "Failed to parse the translation unit (%d)\n", err);
+            exit(1);
+        }
+
+        const int num_diags = clang_getNumDiagnostics(translationUnit);
+        int num_errors = 0;
+        for (int i = 0; i < num_diags; ++i)
+        {
+            CXDiagnostic diag = clang_getDiagnostic(translationUnit, i);
+            CXDiagnosticSeverity severity = clang_getDiagnosticSeverity(diag);
+            CXString s = clang_formatDiagnostic(diag, clang_defaultDiagnosticDisplayOptions());
+
+            if (severity >= CXDiagnostic_Error) {
+                num_errors++;
+                fprintf(stderr, "Error: %s\n", clang_getCString(s));
+            }
+
+            clang_disposeString(s);
+            clang_disposeDiagnostic(diag);
+        }
+
+        if (num_errors > 0) {
+            fprintf(stderr, "Skipping '%s' due to compilation errors\n", filename);
+        } else {
+            // Visit each cursor in the AST
+            CXCursor cursor = clang_getTranslationUnitCursor(translationUnit);
+            VisitorData data;
+            clang_visitChildren(cursor, VisitTU, /*user_data*/&data);
+        }
+
+        // Clean up
+        clang_disposeTranslationUnit(translationUnit);
+        clang_disposeIndex(index);
+        clang_disposeString(directory);
+    }
+    clang_CompileCommands_dispose(commands);
+}
+
+int main(int argc, char **argv) {
+    std::filesystem::path compilationDBPath;
+    std::vector<std::string> skipPaths;
+    std::vector<std::string> defaultSkipPaths = {
+        "src/backend/jit/llvm/",
+        "src/bin/",
+        "src/fe_utils/",
+        "src/interfaces",
+        "src/timezone/",
+        "jit/llvm/",
+        "src/test",
+    };
+
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << "[--skip=<dir or file>...] [--with-annotated] [--no-skip-yacc] <path-to-dir-with-compile_commands.json>" << std::endl;
+        std::cerr << "Options:" << std::endl;
+        std::cerr << "  --skip=<dir or file>      Skip processing for the specified directory or file. Can be used multiple times." << std::endl;
+        std::cerr << "  --with-annotated          Show annotated variables too." << std::endl;
+        std::cerr << "  --no-skip-yacc            Show variables from lexer/parsers too." << std::endl;
+        return 1;
+    }
+
+    // Parse the --skip arguments
+    for (int i = 1; i < argc; ++i) {
+        if (strncmp(argv[i], "--skip=", 7) == 0) {
+            std::string skipPath = argv[i] + 7;  // Extract the path after "--skip="
+            
+            // If skipPath is relative, make it absolute based on compilationDBPath
+            std::filesystem::path resolvedSkipPath(skipPath);
+            if (resolvedSkipPath.is_relative() && !compilationDBPath.empty()) {
+                skipPaths.emplace_back((compilationDBPath / resolvedSkipPath).lexically_normal().string());
+            } else {
+                skipPaths.emplace_back(resolvedSkipPath.lexically_normal().string());
+            }
+        } else if (std::string(argv[i]) == "--with-annotated") {
+            withUnannotated = true;
+        } else if (std::string(argv[i]) == "--no-skip-yacc") {
+            skipYacc = false;
+        } else {
+            compilationDBPath = argv[i];  // First non-"--" argument is the compilation DB path
+        }
+    }
+
+    if (compilationDBPath.empty()) {
+        std::cerr << "Error: Missing path to compile_commands.json." << std::endl;
+        return 1;
+    }
+
+    // Convert default skip paths to absolute paths based on compilationDBPath
+    for (const std::string& path : defaultSkipPaths) {
+        std::filesystem::path absPath = compilationDBPath / path;
+        skipPaths.emplace_back(absPath.lexically_normal().string());
+    }
+
+    // Load the compilation database
+    CXCompilationDatabase_Error error;
+    CXCompilationDatabase compilationDB = clang_CompilationDatabase_fromDirectory(compilationDBPath.c_str(), &error);
+    if (error != CXCompilationDatabase_NoError) {
+        std::cerr << "Failed to load compile_commands.json from directory " << compilationDBPath << std::endl;
+        return 1;
+    }
+
+    // Get all compile commands in the database
+    CXCompileCommands allCommands = clang_CompilationDatabase_getAllCompileCommands(compilationDB);
+    unsigned numCommands = clang_CompileCommands_getSize(allCommands);
+
+    // Process each translation unit (TU) in the compilation database
+    for (unsigned i = 0; i < numCommands; ++i) {
+        CXCompileCommand command = clang_CompileCommands_getCommand(allCommands, i);
+        CXString filename = clang_CompileCommand_getFilename(command);
+        std::string filePath = clang_getCString(filename);
+
+        // Check if filePath should be skipped
+        bool skip = false;
+        for (const std::string& skipPath : skipPaths) {
+            if (filePath.find(skipPath) != std::string::npos) {
+                skip = true;
+                break;
+            }
+        }
+
+        if (!skip) {
+            processTranslationUnit(filePath.c_str(), compilationDB);
+        }
+
+        clang_disposeString(filename);
+    }
+
+    // Clean up
+    clang_CompileCommands_dispose(allCommands);
+    clang_CompilationDatabase_dispose(compilationDB);
+    return 0;
+}

--- a/src/tools/pgguclifetimes/pg_static_vars.cpp
+++ b/src/tools/pgguclifetimes/pg_static_vars.cpp
@@ -140,7 +140,7 @@ process_var(CXCursor current_cursor, std::vector<const char *> annotations)
         fprintf(stderr, "WARNING: Multiple annotations: %s\n", annotation.c_str());
     }
 
-    if (withUnannotated || annotation.empty()) {
+    if (withUnannotated || annotation.empty() || annotations.size() > 1) {
         fprintf(stdout, "[%s]\t%s\t%s\t%s\n",
                 annotation.c_str(),
                 var_name.c_str(),

--- a/src/tools/pgguclifetimes/pg_static_vars.cpp
+++ b/src/tools/pgguclifetimes/pg_static_vars.cpp
@@ -9,9 +9,6 @@
 // Another way is to use meson build system (TODO: test it).
 //
 
-#include <clang-c/Index.h>
-#include <clang-c/CXCompilationDatabase.h>
-
 #include <cstdio>
 #include <vector>
 #include <format>
@@ -21,10 +18,13 @@
 #include <iostream>
 #include <sstream>
 
+#include <clang-c/Index.h>
+#include <clang-c/CXCompilationDatabase.h>
+
 constexpr bool PRINT_TREE_WALK = false;
 
-bool withUnannotated = false;
-bool skipYacc = true;
+static bool withUnannotated = false;
+static bool skipYacc = true;
 
 struct VisitorData
 {
@@ -33,11 +33,12 @@ struct VisitorData
     std::vector<const char*> annotations;
 };
 
-std::set<std::string> known_vars;
+static  std::set<std::string> known_vars;
 
 // Print relevant information about each node maintaining indentation.
 // Disabled by default, set PRINT_TREE_WALK to enable.
-void debug_tree_node(CXCursor current_cursor, VisitorData* data)
+static void
+debug_tree_node(CXCursor current_cursor, VisitorData* data)
 {
     const CXCursorKind cursor_kind = clang_getCursorKind(current_cursor);
     const bool is_attr = clang_isAttribute(cursor_kind) != 0;
@@ -68,7 +69,8 @@ void debug_tree_node(CXCursor current_cursor, VisitorData* data)
     clang_disposeString(display_name);
 }
 
-void process_var(CXCursor current_cursor, std::vector<const char *> annotations)
+static void
+process_var(CXCursor current_cursor, std::vector<const char *> annotations)
 {
     const CXType type = clang_getCursorType(current_cursor);
 
@@ -142,7 +144,8 @@ void process_var(CXCursor current_cursor, std::vector<const char *> annotations)
     }
 }
 
-static CXChildVisitResult VisitTU(CXCursor current_cursor, CXCursor parent, CXClientData client_data)
+static CXChildVisitResult
+VisitTU(CXCursor current_cursor, CXCursor parent, CXClientData client_data)
 {
     VisitorData* data = reinterpret_cast<VisitorData*>(client_data);
     bool top_var_decl = false;
@@ -181,7 +184,8 @@ static CXChildVisitResult VisitTU(CXCursor current_cursor, CXCursor parent, CXCl
 };
 
 // Function to process each translation unit (TU)
-void processTranslationUnit(const char *filename, CXCompilationDatabase compilationDB) {
+static void
+processTranslationUnit(const char *filename, CXCompilationDatabase compilationDB) {
     // Arguments needed for parsing each TU, usually retrieved from the compilation database
     CXCompileCommands commands = clang_CompilationDatabase_getCompileCommands(compilationDB, filename);
 
@@ -278,7 +282,8 @@ void processTranslationUnit(const char *filename, CXCompilationDatabase compilat
     clang_CompileCommands_dispose(commands);
 }
 
-int main(int argc, char **argv) {
+int
+main(int argc, char **argv) {
     std::filesystem::path compilationDBPath;
     std::vector<std::string> skipPaths;
     std::vector<std::string> defaultSkipPaths = {

--- a/src/tools/pgguclifetimes/pg_static_vars.cpp
+++ b/src/tools/pgguclifetimes/pg_static_vars.cpp
@@ -6,8 +6,13 @@
 // example:
 //   bear -- make -j
 //
-// Another way is to use meson build system (TODO: test it).
+// Another way to get compile_commands.json  is to use meson build system (TODO: test it).
 //
+// Once compile_commands.json is generated, run this program with the root directory of the
+// postgres repository:
+//   ./src/tools/pgguclifetimes/pg_static_vars ./
+//
+
 
 #include <cstdio>
 #include <vector>


### PR DESCRIPTION
I've tried enabling thread sanitizer to detect data races and to my surprise it was actually not that hard to make it work and race descriptions were good. Most of races are either harmless (e.g. guc do write types to tables, but always same values) or false positives due to custom mutexes. Marking postgres mutexes with `__tsan_mutex_` works.

Current commits:
* make it compile on macos
* fix few missing thread locals by running `make check` and looking at core dumps
* fix/rewrite of pgguclifetimes -- now it works

Still WIP:
* didn't yet fix any missing annotations found by ./pg_static_vars
* didn't push tsan annotations, wip
